### PR TITLE
docs: seed CHANGELOG.md (Keep-a-Changelog format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,71 @@
+<!--
+SPDX-License-Identifier: MPL-2.0
+SPDX-FileCopyrightText: 2026 Jonathan D.A. Jewell (hyperpolymath)
+-->
+
+# Changelog
+
+All notable changes to `polysafe-gitfixer` will be documented in this file.
+
+This file is generated from conventional commits by the
+[`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml)
+workflow (`hyperpolymath/standards#206`). Adopt the workflow in this repo's CI to keep this file in sync automatically — see
+[`templates/cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml)
+for the canonical config.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- feat(crg): add crg-grade and crg-badge justfile recipes
+- feat: add stapeln.toml container definition
+- feat: add UX Justfile with doctor, tour, help-me, assail recipes
+- feat: deploy UX Manifesto infrastructure
+- feat: add CLADE.a2ml — clade taxonomy declaration
+- feat(ci): enable Hypatia scanning
+
+### Fixed
+
+- fix(ci): bump a2ml/k9-validate-action pins to canonical (#19)
+- fix(ci): sync hypatia-scan.yml to canonical (#18)
+- fix(ci): Phase-2 fleet submission must not fail the security gate (#17)
+- fix(ci): hypatia-scan workdir (${{ env.HOME }} resolves empty) (#16)
+- fix(ci): hypatia-scan.yml -- --exit-zero + GITHUB_TOKEN (hyperpolymath/hypatia#213) (#13)
+- fix(ci): rsr-antipattern duplicate heredoc + setup-beam ubuntu24 (#14)
+- fix(ci): update hypatia binary detection (check 'hypatia' before 'hypatia-v2')
+- fix: implement NIF bindings for polysafe-gitfixer, replacing 12 hollow stubs
+- fix(scorecard): enforce granular permissions and add fuzzing placeholder
+- fix(ci): Resolve workflow-linter self-matching and metadata issues
+
+### Changed
+
+- refactor: migrate 6SCM → 6A2 (.scm → .a2ml format)
+
+### Documentation
+
+- docs: substantive CRG C annotation (EXPLAINME.adoc)
+- docs: add TEST-NEEDS.md and/or PROOF-NEEDS.md from audit
+- docs: add EXPLAINME.adoc — prove-it file backing README claims
+- docs: update SCM files with project information
+- docs: add CONTRIBUTING.md
+- docs: add SCM checkpoint files
+- docs: add checkpoint files for state tracking
+
+### CI
+
+- ci: redistribute concurrency-cancel guard to read-only check workflows (#21)
+- ci: bump actions/upload-artifact SHA to current v4 (#12)
+- ci: SHA-pin hyperpolymath validate-actions in dogfood-gate
+- ci(antipattern): fix top-level dir + benchmark/lsp filename matching (#11)
+- ci(antipattern): TS check reads .claude/CLAUDE.md exemption table (#10)
+
+## Pre-history
+
+Prior commits to this file's introduction are recorded in git history but not formally classified into Keep-a-Changelog sections. To backfill, run `git cliff -o CHANGELOG.md` locally using the canonical [`cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml) — this is one-shot mechanical work.
+
+---
+
+<!-- This file was seeded by the 2026-05-26 estate tech-debt audit follow-up (Row-2 Phase 3); see [`hyperpolymath/standards/docs/audits/2026-05-26-estate-documentation-debt.md`](https://github.com/hyperpolymath/standards/blob/main/docs/audits/2026-05-26-estate-documentation-debt.md). -->


### PR DESCRIPTION
## Summary
Adds an initial `CHANGELOG.md` in Keep-a-Changelog format. Recent commits are bucketed into Added/Fixed/Changed/Documentation/CI from their conventional-commit prefixes.

Closes **Row-2 Phase 3** of the 2026-05-26 estate tech-debt audit chain for this repo. The audit ([standards#197](https://github.com/hyperpolymath/standards/pull/197)) flagged 180/279 repos missing CHANGELOG (65% gap).

## Adopting auto-regeneration
For ongoing auto-regeneration, adopt the [`changelog-reusable.yml`](https://github.com/hyperpolymath/standards/blob/main/.github/workflows/changelog-reusable.yml) workflow ([standards#206](https://github.com/hyperpolymath/standards/pull/206)) in this repo's CI. Uses the canonical [`templates/cliff.toml`](https://github.com/hyperpolymath/standards/blob/main/templates/cliff.toml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)