### PR TITLE
ci(codeql): cron weekly→monthly (cut 3, standards#288)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches: [main, master]
   schedule:
-    - cron: '0 6 * * 1'
+    - cron: '0 6 1 * *'   # monthly 1st 06:00 UTC
 
 # Estate guardrail: cancel superseded runs so re-pushes / rebased PR
 # updates do not pile up queued runs against the shared account-wide


### PR DESCRIPTION
Per `standards#286` canonical (cut 3, Option B 2026-05-30): convert CodeQL scheduled run from weekly `0 6 * * 1` to monthly `0 6 1 * *`. PR-trigger runs unchanged — every PR still gets CodeQL.

Refs `hyperpolymath/standards#288` (campaign).

<!--
SPDX-License-Identifier: CC-BY-SA-4.0
Copyright (c) Jonathan D.A. Jewell <j.d.a.jewell@open.ac.uk>
-->
## Summary

<!-- What does this PR do, and why? -->

Closes #

## Type of change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (would change existing behaviour)
- [ ] 🕳️ Soundness fix (fixes a checker/proof false-negative)
- [ ] 📖 Documentation
- [ ] 🧹 Refactor / tech debt (behaviour-preserving)
- [ ] ⚡ Performance
- [ ] 🔧 Build / CI / tooling

## How has this been verified?

<!-- Establish ground truth: which tool did you RUN, and what did it report?
     Don't cite a status doc — cite the command and its output. -->

## Checklist

- [ ] My commits are **signed** (`git commit -S`).
- [ ] I ran the project's own checks/tests locally and they pass.
- [ ] New files carry the correct `SPDX-License-Identifier` (code/config `MPL-2.0`,
      prose `CC-BY-SA-4.0`); I did not relicense existing files.
- [ ] Docs are updated, and no public claim now overstates what the code does.
- [ ] I have not introduced a soundness hole (or I have flagged where I might have).

## Notes for reviewers

<!-- Anything that needs special attention, follow-up, or context. -->
